### PR TITLE
feat(dj_lazy_schema): :sparkles: add lazy schema and generic functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,5 @@ notebook
 
 # misc
 **/*.DS_Store
+./experimental
+datajoint_utilities/experimental

--- a/datajoint_utilities/dj_lazy_schema/README.md
+++ b/datajoint_utilities/dj_lazy_schema/README.md
@@ -1,0 +1,48 @@
+# `dj_lazy_schema`
+
+> **Note**: This subdirectory is fully typed using python inline typing. It requires `python>=3.10` for some of the functionality.
+
+## Problem
+
+Your package may be organized such that the directory tree corresponds to the schema names, or you may want to specify a schema name during initialization but not require activation.
+
+`LazySchema` ([`datajoint_utilities.dj_lazy_schema.lazy_schema:LazySchema`](./lazy_schema.py)) modifies the DataJoint `Schema` class to always delay activation of a `Schema` instance, later using stored context information for activation as well as for automatically generating schema names.
+
+## Usage
+
+If the code snippet below is taken from a file located at `my_pkg/pipeline/sources/subjects.py` within the package `my_pkg`:
+
+```python
+import datajoint as dj
+from datajoint_utilities.dj_lazy_schema import LazySchema
+
+dj.config["custom"] = {"database.prefix": "my_db"}
+
+# no schema name provided
+schema = LazySchema() # -> schema_name = 'my_db_sources_subjects'
+schema.is_activated()  # -> False
+
+# schema name provided
+another_schema = LazySchema("some_db") # -> schema_name = "some_db"
+another_schema.is_activated()  # -> False
+
+... # subjects tables
+
+# activate can be in the same file or from another file
+schema.activate()
+another_schema.activate()
+```
+
+The schema suffix can be truncated to start at a subdirectory name other than `'pipeline'`:
+
+```python
+schema = LazySchema(start_dirname="sources") # -> schema_name = 'my_db_subjects'
+```
+
+## `__init__.py`
+
+Shortcut to import the `LazySchema` class from `lazy_schema.py`.
+
+## `lazy_schema.py`
+
+`LazySchema` Overrides the default behavior of the "activation" functionality from the `datajoint.Schema` class. If the `schema_name` argument is left blank during initialization, it will try to use the `dj.config`'s database prefix, as well as the call stack to generate a default schema name based on the calling source file. Unlike the default behavior for `Schema`, activation will never happen during initialization, even if a schema name is provided. The method `activate` must be called at least once at a later point in the pipeline.

--- a/datajoint_utilities/dj_lazy_schema/__init__.py
+++ b/datajoint_utilities/dj_lazy_schema/__init__.py
@@ -1,0 +1,3 @@
+from datajoint_utilities.dj_lazy_schema.lazy_schema import LazySchema
+
+__all__ = ["LazySchema"]

--- a/datajoint_utilities/dj_lazy_schema/lazy_schema.py
+++ b/datajoint_utilities/dj_lazy_schema/lazy_schema.py
@@ -1,8 +1,8 @@
 import datajoint_utilities.typing as djt  # isort: skip
 
 import inspect
+import typing as typ
 from pathlib import Path
-from typing import Any, Mapping, NoReturn
 
 import datajoint as dj
 import datajoint_utilities.generic.typed as gt
@@ -54,7 +54,7 @@ class LazySchema(dj.Schema):
         create_schema: bool = True,
         create_tables: bool = True,
         add_objects: djt.ContextLike | None = None,
-        **kwargs: Any,
+        **kwargs: typ.Any,
     ):
         super().__init__(
             schema_name=None,
@@ -96,7 +96,7 @@ class LazySchema(dj.Schema):
         add_context = self._context_info(self.add_objects) or {}
         add_context |= self._context_info(add_objects) or {}
         if not self._is_active():
-            self.declare_list: list[tuple[object, dict[str, Any]]] = [
+            self.declare_list: list[tuple[object, dict[str, typ.Any]]] = [
                 (cls, self._context_info(context) or {})
                 for cls, context in self.declare_list
                 if context is not None
@@ -111,10 +111,10 @@ class LazySchema(dj.Schema):
 
     def _context_info(
         self, context: djt.ContextLike | None
-    ) -> dict[str, Any] | None | NoReturn:
+    ) -> dict[str, typ.Any] | None | typ.NoReturn:
         if context is None:
             return None
-        if isinstance(context, Mapping):
+        if isinstance(context, typ.Mapping):
             return dict(context)
         if djt.is_frame_stack(context):
             return gt.calling_frame_locals(context)

--- a/datajoint_utilities/dj_lazy_schema/lazy_schema.py
+++ b/datajoint_utilities/dj_lazy_schema/lazy_schema.py
@@ -76,7 +76,7 @@ class LazySchema(dj.Schema):
             raise ValueError("No context provided.")
         if djt.is_parttable(cls):
             raise dj.errors.DataJointError(
-                "The schema decorator should not be applied to Part relations"
+                "The schema decorator should not be applied to Part tables."
             )
         if self.is_activated():
             self._decorate_master(cls, self._context_info(context))  # type: ignore

--- a/datajoint_utilities/dj_lazy_schema/lazy_schema.py
+++ b/datajoint_utilities/dj_lazy_schema/lazy_schema.py
@@ -1,0 +1,133 @@
+import datajoint_utilities.typing as djt  # isort: skip
+
+import inspect
+from pathlib import Path
+from typing import Any, Mapping, NoReturn
+
+import datajoint as dj
+import datajoint_utilities.generic.typed as gt
+
+
+def _src_file_relative_to_pkg(
+    source: djt.FrameStack, package: djt.StrNone = None
+) -> gt.SourceFileInfo | None:
+    src_file = gt.filepath_from_frame(source)
+    if not (src_file and src_file.is_absolute()):
+        return None
+    pkg_name = package or gt.pkg_name_from_frame(source)
+    src_file_pkg_relpath = gt.pkg_relpath(src_file, package_import_name=pkg_name)
+    if not src_file_pkg_relpath:
+        return None
+    return gt.SourceFileInfo(src_file, pkg_name, src_file_pkg_relpath)
+
+
+def make_lazy_schema_name(
+    source: djt.FrameStack | None,
+    package: djt.StrNone = None,
+    *,
+    start_dirname: djt.StrPathNone = None,
+) -> djt.StrNone:
+    src = _src_file_relative_to_pkg(source or inspect.stack(), package)
+    if src is None:
+        return None
+    pkg_relparts = src.pkg_relpath.parts if src.pkg_relpath else (src.file.name,)
+    if start_dirname is None and "pipeline" in pkg_relparts:
+        start_dirname = "pipeline"
+    if src.pkg_relpath and start_dirname:
+        root_schema_idx = [i for i, x in enumerate(pkg_relparts) if x == start_dirname]
+        if root_schema_idx and len(pkg_relparts) > 1:
+            pkg_relparts = tuple(pkg_relparts[root_schema_idx[0] + 1 :])
+    schema_suffix = gt.chain_path_parts(Path(*pkg_relparts), sep="_")
+    to_append = {"name": schema_suffix}
+    if src.pkg_name:
+        to_append["fallback"] = src.pkg_name
+    return gt.append_to_prefix(**to_append)
+
+
+class LazySchema(dj.Schema):
+    def __init__(
+        self,
+        schema_name: djt.StrNone = None,
+        context: djt.ContextLike | None = None,
+        *,
+        connection: djt.DBConnection | None = None,
+        create_schema: bool = True,
+        create_tables: bool = True,
+        add_objects: djt.ContextLike | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            schema_name=None,
+            connection=connection,
+            create_schema=create_schema,
+            create_tables=create_tables,
+        )
+        self.context = context
+        self.add_objects = add_objects
+        self._lazy_schema_name = schema_name or make_lazy_schema_name(
+            kwargs.pop("source", None) or inspect.currentframe(), **kwargs
+        )
+
+    def __call__(
+        self, cls: type[djt.T_UserTable], *, context: djt.ContextLike | None = None
+    ) -> type[djt.T_UserTable]:
+        context = context or self.context or inspect.currentframe()
+        if context is None:
+            raise ValueError("No context provided.")
+        if djt.is_parttable(cls):
+            raise dj.errors.DataJointError(
+                "The schema decorator should not be applied to Part relations"
+            )
+        if self.is_activated():
+            self._decorate_master(cls, self._context_info(context))  # type: ignore
+        else:
+            self.declare_list.append((cls, context))  # type: ignore
+        return cls
+
+    def activate(
+        self,
+        schema_name: djt.StrNone = None,
+        *,
+        connection: djt.DBConnection | None = None,
+        create_schema: bool | None = None,
+        create_tables: bool | None = None,
+        add_objects: djt.ContextLike | None = None,
+    ) -> None:
+        add_context = self._context_info(self.add_objects) or {}
+        add_context |= self._context_info(add_objects) or {}
+        if not self._is_active():
+            self.declare_list: list[tuple[object, dict[str, Any]]] = [
+                (cls, self._context_info(context) or {})
+                for cls, context in self.declare_list
+                if context is not None
+            ]
+        super().activate(  # type: ignore
+            schema_name=schema_name or self._lazy_schema_name,
+            connection=connection,
+            create_schema=create_schema,
+            create_tables=create_tables,
+            add_objects=add_context,
+        )
+
+    def _context_info(
+        self, context: djt.ContextLike | None
+    ) -> dict[str, Any] | None | NoReturn:
+        if context is None:
+            return None
+        if isinstance(context, Mapping):
+            return dict(context)
+        if djt.is_frame_stack(context):
+            return gt.calling_frame_locals(context)
+        if isinstance(context, (str, djt.ModuleType)):
+            return gt.get_module_objects(context)
+        raise TypeError(f"Invalid context type: {type(context).__name__}")
+
+    def _is_active(self) -> bool:
+        if not self.is_activated() or self.connection is None:  # type: ignore
+            return False
+        return bool(
+            self.connection.query(  # type: ignore
+                "SELECT schema_name FROM information_schema.schemata "
+                f"WHERE schema_name = '{self.database}'"  # type: ignore
+            ).rowcount
+        )

--- a/datajoint_utilities/dj_search/lists.py
+++ b/datajoint_utilities/dj_search/lists.py
@@ -34,7 +34,7 @@ def list_drop_order(prefix):
     while depends_on:
         drop_list += [k for k, v in depends_on.items() if not v]  # empty is dropable
         depends_on = {k: v for k, v in depends_on.items() if v}  # remove from dict
-        for schema in depends_on.keys():
+        for schema in depends_on:
             # Filter out items already in drop list
             depends_on[schema] = [s for s in depends_on[schema] if s not in drop_list]
 

--- a/datajoint_utilities/dj_search/lists.py
+++ b/datajoint_utilities/dj_search/lists.py
@@ -74,7 +74,7 @@ def drop_schemas(prefix, dry_run=True, ordered=False, force_drop=False):
 
     elif not dry_run:
         while schemas_with_prefix:
-            recent_errs = []  # Refresh recent_errs at start of while loop
+            recent_errs = []
             n_schemas_initial = len(schemas_with_prefix)
             for schema_name in schemas_with_prefix:
                 try:

--- a/datajoint_utilities/dj_search/lists.py
+++ b/datajoint_utilities/dj_search/lists.py
@@ -80,7 +80,7 @@ def drop_schemas(prefix, dry_run=True, ordered=False, force_drop=False):
                 try:
                     dj.schema(schema_name).drop(force=force_drop)
                 except (OperationalError, IntegrityError) as e:
-                    recent_errs = [*recent_errs, str(e)]  # Add to list for current loop
+                    recent_errs.append(str(e))  # Add to list for current loop
                 else:
                     schemas_with_prefix.remove(schema_name)
                     if force_drop:

--- a/datajoint_utilities/dj_search/lists.py
+++ b/datajoint_utilities/dj_search/lists.py
@@ -1,11 +1,11 @@
 import datajoint as dj
-from pymysql import OperationalError
+from pymysql import IntegrityError, OperationalError
 
 """
 Development helper functions. Chris Brozdowski <CBroz@datajoint.com>
 - list_schemas_prefix: returns a list of schemas with a specific prefix
 - drop_schemas: Cycles through schemas on a given prefix until all are dropped
-- list_drop_order: Cycles though schemas with a given prefix. List schemas in an order 
+- list_drop_order: Cycles though schemas with a given prefix. List schemas in an order
                    that they could be dropped, to avoid foreign key constraints
 """
 
@@ -79,7 +79,7 @@ def drop_schemas(prefix, dry_run=True, ordered=False, force_drop=False):
             for schema_name in schemas_with_prefix:
                 try:
                     dj.schema(schema_name).drop(force=force_drop)
-                except OperationalError as e:
+                except (OperationalError, IntegrityError) as e:
                     recent_err = e
                 else:
                     schemas_with_prefix.remove(schema_name)

--- a/datajoint_utilities/dj_search/lists.py
+++ b/datajoint_utilities/dj_search/lists.py
@@ -31,7 +31,7 @@ def list_drop_order(prefix):
             # add schema to the list of schema dependents
             depends_on[upstream] = [*depends_on[upstream], schema]
     drop_list = []  # ordered list to drop
-    while len(depends_on):
+    while depends_on:
         drop_list += [k for k, v in depends_on.items() if not v]  # empty is dropable
         depends_on = {k: v for k, v in depends_on.items() if v}  # remove from dict
         for schema in depends_on.keys():

--- a/datajoint_utilities/dj_search/lists.py
+++ b/datajoint_utilities/dj_search/lists.py
@@ -2,7 +2,7 @@ import datajoint as dj
 from pymysql import IntegrityError, OperationalError
 
 """
-Development helper functions. Chris Brozdowski <CBroz@datajoint.com>
+Development helper functions.
 - list_schemas_prefix: returns a list of schemas with a specific prefix
 - drop_schemas: Cycles through schemas on a given prefix until all are dropped
 - list_drop_order: Cycles though schemas with a given prefix. List schemas in an order
@@ -17,7 +17,6 @@ def list_schemas_prefix(prefix):
 
 def list_drop_order(prefix):
     """Returns schema order from bottom-up"""
-    # TODO: better integrate with DJSearch init that calls all contents at once
     schema_list = list_schemas_prefix(prefix=prefix)
     # schemas as dictionary of empty lists
     depends_on = {s: [] for s in schema_list}
@@ -35,8 +34,8 @@ def list_drop_order(prefix):
     while len(depends_on):
         drop_list += [k for k, v in depends_on.items() if not v]  # empty is dropable
         depends_on = {k: v for k, v in depends_on.items() if v}  # remove from dict
-        remaining = depends_on.keys()  # can't change dict in loop
-        for schema in remaining:  # remove dropable from other values
+        for schema in depends_on.keys():  # remove dropable from other values
+            # Filter out items already in drop list
             depends_on[schema] = [s for s in depends_on[schema] if s not in drop_list]
 
     return drop_list
@@ -75,18 +74,20 @@ def drop_schemas(prefix, dry_run=True, ordered=False, force_drop=False):
 
     elif not dry_run:
         while schemas_with_prefix:
+            recent_errs = ["\t"]
             n_schemas_initial = len(schemas_with_prefix)
             for schema_name in schemas_with_prefix:
                 try:
                     dj.schema(schema_name).drop(force=force_drop)
                 except (OperationalError, IntegrityError) as e:
-                    recent_err = e
+                    recent_errs = [*recent_errs, str(e)]
                 else:
                     schemas_with_prefix.remove(schema_name)
                     if force_drop:
                         print(schema_name)
+            recent_errs_concat = "\n\t".join(recent_errs)
             assert n_schemas_initial != len(schemas_with_prefix), (
                 f"Could not drop any of the following schemas:\n\t"
                 + "\n\t".join(schemas_with_prefix)
-                + f"\nMost recent error:\n\t{recent_err}"
+                + f"\Recent errors:{recent_errs_concat}"
             )

--- a/datajoint_utilities/dj_search/lists.py
+++ b/datajoint_utilities/dj_search/lists.py
@@ -34,7 +34,7 @@ def list_drop_order(prefix):
     while len(depends_on):
         drop_list += [k for k, v in depends_on.items() if not v]  # empty is dropable
         depends_on = {k: v for k, v in depends_on.items() if v}  # remove from dict
-        for schema in depends_on.keys():  # remove dropable from other values
+        for schema in depends_on.keys():
             # Filter out items already in drop list
             depends_on[schema] = [s for s in depends_on[schema] if s not in drop_list]
 
@@ -74,20 +74,20 @@ def drop_schemas(prefix, dry_run=True, ordered=False, force_drop=False):
 
     elif not dry_run:
         while schemas_with_prefix:
-            recent_errs = ["\t"]
+            recent_errs = []  # Refresh recent_errs at start of while loop
             n_schemas_initial = len(schemas_with_prefix)
             for schema_name in schemas_with_prefix:
                 try:
                     dj.schema(schema_name).drop(force=force_drop)
                 except (OperationalError, IntegrityError) as e:
-                    recent_errs = [*recent_errs, str(e)]
+                    recent_errs = [*recent_errs, str(e)]  # Add to list for current loop
                 else:
                     schemas_with_prefix.remove(schema_name)
                     if force_drop:
                         print(schema_name)
-            recent_errs_concat = "\n\t".join(recent_errs)
             assert n_schemas_initial != len(schemas_with_prefix), (
                 f"Could not drop any of the following schemas:\n\t"
                 + "\n\t".join(schemas_with_prefix)
-                + f"\Recent errors:{recent_errs_concat}"
+                + f"\Recent errors:\n\t"
+                + "\n\t".join(recent_errs)
             )

--- a/datajoint_utilities/generic/README.md
+++ b/datajoint_utilities/generic/README.md
@@ -1,0 +1,11 @@
+# Generic utilities
+
+Location to store generic utilities that can be used across modules and packages and should not be overly specific to some cases. Most likely separate functions or small classes that don't need their own module. 
+
+## `pkgutil.py`
+
+Generic, untyped package utilities.
+
+## `typed.py`
+
+Generic, typed utilities to be used across typed modules.

--- a/datajoint_utilities/generic/pkgutil.py
+++ b/datajoint_utilities/generic/pkgutil.py
@@ -1,0 +1,9 @@
+# type: ignore
+
+
+def detect_min_python_version(major=3, minor=10, micro=0):
+    import sys
+
+    min_py = (major, minor, micro)
+    if sys.version_info < min_py:
+        raise RuntimeError("Python %s.%s.%s or later is required.\n" % min_py)

--- a/datajoint_utilities/generic/typed.py
+++ b/datajoint_utilities/generic/typed.py
@@ -154,22 +154,16 @@ def as_path_parts(file_or_parts: djt.StrPath) -> djt.StrTuple:
 
 
 def as_path_parts(file_or_parts: djt.StrPathParts) -> djt.StrTuple:
-    """no extension at end
+    """Like `Path().parts` but with no extension at end.
 
     Args:
-        file_or_parts (djt.StrPathParts): _description_
+        file_or_parts (djt.StrPathParts): A sequence of path parts or a path string to get parts from.
 
     Raises:
-        TypeError: _description_
+        TypeError: Incorrect type of argument.
 
     Returns:
-        djt.StrTuple: _description_
-
-    Examples:
-        Examples should be written in doctest format and should illustrate how to use
-        the function.
-
-            my_function(x="value")
+        djt.StrTuple: A sequence of path parts.
     """
     if file_or_parts is None:
         return djt.StrTuple()
@@ -552,6 +546,7 @@ def append_to_prefix(name: str, **kwargs: str) -> str:
 
     Args:
         name (str): Name of module to append to database prefix.
+        kwargs (str): Keyword arguments passed to `get_prefix`.
 
     Returns:
         string: Extended database prefix.
@@ -586,7 +581,6 @@ def set_missing_configs(
         file (Path | str | None): Path to initialize a datajoint `JSON` config
             file before setting the rest of the arguments.
     """
-
     if file:
         dj.config.load(file)
 
@@ -615,13 +609,14 @@ def insert_row(
 
 def dj_table_info(table: djt.UserTable, name_prefix: str = "") -> str:
     db_name: str = table.database  # type: ignore
-    if table.database is None or table.heading is None:
+    cls_name: str = table.__name__ or ""  # type: ignore
+    if table.database is None or table.heading is None or not cls_name:
         raise dj.errors.DataJointError(
-            f"Class {table.__name__} is not properly declared "
+            f"Class {cls_name} is not properly declared "
             "(schema decorator not applied?)"
         )
     db_table_name: str = table.table_name  # type: ignore
-    table_name = f"{name_prefix}.{table.__name__}" if name_prefix else table.__name__
+    table_name = f"{name_prefix}.{cls_name}" if name_prefix else cls_name
     table_comment: str = (
         table.heading.table_status["comment"] if table.heading.table_status else ""
     )

--- a/datajoint_utilities/generic/typed.py
+++ b/datajoint_utilities/generic/typed.py
@@ -238,7 +238,7 @@ def arr_bool(obj: object) -> bool:
 def _in_switch(
     x: typ.Container[object], y: typ.Container[object], is_in: bool = True
 ) -> bool:
-    return x in y if is_in else x not in y
+    return x in y == is_in
 
 
 def _extract(

--- a/datajoint_utilities/generic/typed.py
+++ b/datajoint_utilities/generic/typed.py
@@ -1,0 +1,612 @@
+import datajoint_utilities.typing as djt  # isort: skip
+
+import datetime as dt
+import hashlib
+import inspect
+import itertools
+import json
+import os
+from dataclasses import dataclass, field
+from importlib import import_module
+from importlib.metadata import PackageNotFoundError, packages_distributions
+from importlib.util import find_spec
+from pathlib import Path
+from typing import (
+    ClassVar,
+    Container,
+    Iterable,
+    Literal,
+    Mapping,
+    NoReturn,
+    Sequence,
+    TypedDict,
+    cast,
+    overload,
+)
+from uuid import UUID
+
+import datajoint as dj
+from datajoint.errors import MissingTableError, QueryError
+from typing_extensions import Unpack
+
+
+# frame stack functions ----------------------------------------------------------------
+def select_stack_frame(stack: djt.FrameInfoList, back: int = 1) -> djt.FrameInfo | None:
+    return stack[back] if len(stack) > back else None
+
+
+def calling_frame(frame: djt.FrameStack) -> djt.FrameType | None | NoReturn:
+    if djt.is_frame(frame):
+        return frame.f_back or None
+    if djt.is_frame_info_list(frame):
+        f_back = select_stack_frame(frame, 1)
+        return f_back.frame if f_back else None
+    raise TypeError(
+        f"Argument must be of type `list[inspect.FrameInfo] | types.FrameType`"
+        f", not '{type(frame).__name__}'."
+    )
+
+
+def calling_frame_locals(frame: djt.FrameStack) -> djt.DictObj:
+    cf = calling_frame(frame)
+    return cf.f_locals if cf else {}
+
+
+def calling_frame_globals(frame: djt.FrameStack) -> djt.DictObj:
+    cf = calling_frame(frame)
+    return cf.f_globals if cf else {}
+
+
+def calling_frame_file(frame: djt.FrameStack) -> Path | None:
+    cf = calling_frame(frame)
+    return Path(cf.f_code.co_filename) if cf else None
+
+
+def get_module_objects(
+    module: str | djt.ModuleType, must_work: bool = True
+) -> djt.DictObj | None | NoReturn:
+    if isinstance(module, str):
+        module = import_module(module)
+    if inspect.ismodule(module):
+        return vars(module)
+    if must_work:
+        raise TypeError(
+            f"The argument 'module'<{type(module).__name__}> must be "
+            "a module's name as a string or ModuleType object."
+        )
+    return None
+
+
+def module_name_from_frame(source: djt.FrameStack) -> str:
+    frame = calling_frame(source)
+    module = inspect.getmodule(frame)
+    if module is None:
+        return ""
+    module_name = getattr(module.__spec__, "name", "")
+    if not module_name and module.__name__ == "__main__":
+        module_name = Path(module.__file__).stem if module.__file__ else ""
+    return module_name
+
+
+def pkg_name_from_frame(source: djt.FrameStack, fallback: str = "") -> str:
+    module_root = module_name_from_frame(source).split(".", maxsplit=1)[0]
+    return (
+        module_root
+        if module_root and module_root in packages_distributions()
+        else fallback
+    )
+
+
+# path functions -----------------------------------------------------------------------
+@overload
+def pkg_abspath(
+    import_name: djt.StrNone = None,
+    must_exist: Literal[True] = True,
+) -> Path | NoReturn:
+    ...
+
+
+@overload
+def pkg_abspath(
+    import_name: djt.StrNone = None,
+    must_exist: Literal[False] = False,
+) -> Path | None:
+    ...
+
+
+def pkg_abspath(
+    import_name: djt.StrNone = None,
+    must_exist: Literal[True, False] = True,
+) -> Path | None | NoReturn:
+    import_name = import_name or pkg_name_from_frame(inspect.stack())
+    pkg_spec = find_spec(import_name)
+    if not pkg_spec:
+        if must_exist:
+            raise PackageNotFoundError(import_name)
+        return None
+    return Path(str(pkg_spec.origin)).parent
+
+
+def pkg_relpath(
+    file: djt.StrPath,
+    *,
+    package_import_name: djt.StrNone = None,
+    package_root_path: djt.StrPathNone = None,
+    append_to_package_root_path: djt.StrPathNone = None,
+) -> Path | None:
+    src_path = Path(file)
+    root_path = Path(package_root_path or pkg_abspath(package_import_name))
+    if append_to_package_root_path:
+        root_path /= append_to_package_root_path
+    src_is_rel = src_path.is_relative_to(root_path)
+    return src_path.relative_to(root_path) if src_is_rel else None
+
+
+@overload
+def as_path_parts(file_or_parts: djt.StrTuple) -> djt.StrTuple:
+    ...
+
+
+@overload
+def as_path_parts(file_or_parts: djt.StrPath) -> djt.StrTuple:
+    ...
+
+
+def as_path_parts(file_or_parts: djt.StrPathParts) -> djt.StrTuple:
+    """no extension at end
+
+    Args:
+        file_or_parts (djt.StrPathParts): _description_
+
+    Raises:
+        TypeError: _description_
+
+    Returns:
+        djt.StrTuple: _description_
+
+    Examples:
+        Examples should be written in doctest format and should illustrate how to use
+        the function.
+
+            my_function(x="value")
+    """
+    if file_or_parts is None:
+        return djt.StrTuple()
+
+    if isinstance(file_or_parts, (tuple, list)):
+        parts = file_or_parts
+
+    elif djt.is_pathstr(file_or_parts):
+        file_or_parts = Path(file_or_parts)
+        parts = (*file_or_parts.parts[:-1], file_or_parts.stem)
+    else:
+        raise TypeError(
+            f"argument must be of type <{djt.StrPathParts}>, "
+            f"not '{type(file_or_parts)}'"
+        )
+
+    return (*filter(None, parts),)
+
+
+def chain_path_parts(*args: djt.StrPathParts, sep: str = ".") -> str:
+    part_gen = (as_path_parts(parts) for parts in args)
+    return sep.join(itertools.chain.from_iterable(part_gen))
+
+
+def filepath_from_frame(source: str | Path | djt.FrameStack | None) -> Path | None:
+    if djt.is_frame_stack(source):
+        return calling_frame_file(source)
+    if djt.is_pathstr(source) and source:
+        return Path(source)
+    return None
+
+
+@dataclass
+class SourceFileInfo:
+    file: Path = field(default_factory=Path)
+    pkg_name: str = ""
+    pkg_relpath: Path = field(default_factory=Path)
+
+
+# datetime functions -------------------------------------------------------------------
+def datetime_to_utcaware(
+    datetime: dt.datetime, tzinfo: dt.tzinfo | None = None
+) -> dt.datetime:
+    local_date = datetime.astimezone(tz=tzinfo)
+    dt_diff = local_date - (local_date.utcoffset() or dt.timedelta(0))
+    return dt_diff.replace(tzinfo=dt.timezone.utc)
+
+
+def date_to_utcaware(date: dt.date, tzinfo: dt.tzinfo | None = None) -> dt.datetime:
+    return datetime_to_utcaware(dt.datetime(date.year, date.month, date.day), tzinfo)
+
+
+def from_utc_timestamp(timestamp: int, *, precision: float = 1e6) -> dt.datetime:
+    return dt.datetime.fromtimestamp(timestamp / precision, dt.timezone.utc)
+
+
+def utc_timestamp(
+    datetime: djt.TimeStampable | None = None,
+    *,
+    precision: float = 1e6,
+    tzinfo: dt.tzinfo | None = None,
+) -> int:
+    if isinstance(datetime, dt.date):
+        datetime = date_to_utcaware(datetime, tzinfo)
+    elif isinstance(datetime, dt.datetime):
+        datetime = datetime_to_utcaware(datetime, tzinfo)
+    elif isinstance(datetime, dt.timedelta):
+        datetime = from_utc_timestamp(0, precision=precision) + datetime
+    else:
+        datetime = dt.datetime.now(tz=dt.timezone.utc)
+    return int(round(datetime.timestamp() * precision))
+
+
+# misc functions -----------------------------------------------------------------------
+def is_empty_string(string: object, none_as_empty: bool = True) -> bool:
+    if string is None:
+        return none_as_empty
+    return isinstance(string, str) and string == ""
+
+
+def arr_bool(obj: object) -> bool:
+    return obj.size != 0 if djt.is_ndarray(obj) else bool(obj)
+
+
+def _in_switch(x: Container[object], y: Container[object], is_in: bool = True) -> bool:
+    return x in y if is_in else x not in y
+
+
+def _extract(
+    dict_: djt.AnyMap,
+    keys: Iterable[str],
+    *,
+    prefix: str = "",
+    suffix: str = "",
+    keep: bool = True,
+) -> djt.DictObj:
+    return {
+        f"{prefix}{key}{suffix}": dict_[key]
+        for key in keys
+        if _in_switch(key, dict_, keep)
+    }
+
+
+class _ExtractOptions(TypedDict, total=False):
+    prefix: str
+    suffix: str
+    keep: bool
+
+
+@overload
+def subset(
+    dict_or_seq_of: Sequence[djt.AnyMap],
+    *dict_keys: str,
+    **options: Unpack[_ExtractOptions],
+) -> list[djt.DictObj]:
+    ...
+
+
+@overload
+def subset(
+    dict_or_seq_of: djt.AnyMap,
+    *dict_keys: str,
+    **options: Unpack[_ExtractOptions],
+) -> djt.DictObj:
+    ...
+
+
+def subset(
+    dict_or_seq_of: djt.AnyMapMapSeq,
+    *dict_keys: str,
+    **options: Unpack[_ExtractOptions],
+) -> list[djt.DictObj] | djt.DictObj:
+    if isinstance(dict_or_seq_of, Sequence):
+        return [_extract(map_, dict_keys, **options) for map_ in dict_or_seq_of]
+    if djt.is_strmap(dict_or_seq_of):
+        return _extract(dict_or_seq_of, dict_keys, **options)
+    raise TypeError("First argument to subset() must be a dict or list[dict].")
+
+
+class EnumNAError(Exception):
+    def __init__(self, enum: djt.StrNone = "NA") -> None:
+        txt = f": '{enum}'" if enum else ""
+        self.message = f"Invalid enum value{txt}."
+        super().__init__(self.message)
+
+
+def assert_enum(enum: djt.StrNone, enums: Container[str]) -> None | NoReturn:
+    if not enum or enum == "NA" or enum not in enums:
+        raise EnumNAError(enum)
+    return None
+
+
+# keyword arguments functions ----------------------------------------------------------
+class KWA:
+    _table_insert: ClassVar[djt.InsertOpts] = {
+        "replace": False,
+        "skip_duplicates": False,
+        "ignore_extra_fields": False,
+        "allow_direct_insert": None,
+    }
+
+    @staticmethod
+    def _keys_iterable(map_: djt.AnyMapStrSeq) -> list[str]:
+        if isinstance(map_, Mapping):
+            return list(map_.keys())
+        elif isinstance(map_, str):
+            return [map_]
+        else:
+            return list(map_)
+
+    @staticmethod
+    def _pop_kwargs(keys_from: djt.AnyMapStrSeq, kwargs: djt.AnyMutMap) -> djt.DictObj:
+        keys = KWA._keys_iterable(keys_from)
+        return {k: kwargs.pop(k) for k in keys if k in kwargs}
+
+    @classmethod
+    def pop_insert_opts(cls, kwargs: djt.AnyMutMap) -> djt.InsertOpts:
+        return cast(djt.InsertOpts, cls._pop_kwargs(cls._table_insert, kwargs))
+
+    @classmethod
+    def pop_kwargs(
+        cls, keys_from: djt.AnyMapStrSeq, kwargs: djt.AnyMutMap
+    ) -> djt.DictObj:
+        return cls._pop_kwargs(keys_from, kwargs)
+
+    @classmethod
+    def pop_tbl_names(
+        cls,
+        kwargs: djt.AnyMutMap,
+        tbl: djt.AnyTable,
+        which: djt.HeadingProp = "names",
+    ) -> djt.DictObj:
+        attrs = getattr(tbl.heading, which, {})
+        return cls._pop_kwargs(attrs, kwargs)
+
+    @staticmethod
+    def _split_kwargs(
+        keys_from: djt.AnyMapStrSeq, kwargs: djt.AnyMutMap
+    ) -> tuple[djt.DictObj, djt.DictObj]:
+        keys = KWA._keys_iterable(keys_from)
+        extracted_kwargs = subset(kwargs, *keys)
+        other_kwargs = {
+            k: v for k, v in kwargs.items() if k not in extracted_kwargs.keys()
+        }
+        return extracted_kwargs, other_kwargs
+
+    @classmethod
+    def split_insert_opts(
+        cls, kwargs: djt.AnyMutMap
+    ) -> tuple[djt.InsertOpts, djt.DictObj]:
+        extracted, other = cls._split_kwargs(cls._table_insert, kwargs)
+        return cast(djt.InsertOpts, extracted), other
+
+    @classmethod
+    def split_tbl_names(
+        cls,
+        kwargs: djt.AnyMutMap,
+        tbl: djt.AnyTable,
+        property: djt.HeadingProp = "names",
+    ) -> tuple[djt.DictObj, djt.DictObj]:
+        attrs = getattr(tbl.heading, property, {})
+        return cls._split_kwargs(attrs, kwargs)
+
+    @classmethod
+    def filter_bool(cls, kwargs: djt.AnyMap) -> djt.DictObj:
+        return {k: v for k, v in kwargs.items() if arr_bool(v)}
+
+
+def get_part_tbl(cls: type[djt.T_Table], part: str) -> dj.Part:
+    part_table = getattr(cls, part, None)
+    if not djt.is_parttable(part_table):
+        raise MissingTableError(f"Failed to get part table '{part}' from {cls}.")
+    return part_table
+
+
+# uuid functions -----------------------------------------------------------------------
+def norm_uuid(uuid: object = None) -> UUID | None:
+    return UUID(str(uuid)) if djt.is_uuid_str(uuid) else None
+
+
+def json_defaults(obj: object) -> object | NoReturn:
+    if djt.is_timestampable(obj):
+        return utc_timestamp(obj)
+    if djt.is_uuid_str(obj):
+        return (
+            str(obj)
+            .replace("urn:", "")
+            .replace("uuid:", "")
+            .strip("{}")
+            .replace("-", "")
+        )
+    try:
+        return str(obj)
+    except Exception as err:
+        raise TypeError(
+            f"Object of type '{type(obj).__name__}' is not serializable."
+        ) from err
+
+
+def json_dumps(obj: object) -> str:
+    return json.dumps(
+        obj,
+        default=json_defaults,
+        ensure_ascii=False,
+        sort_keys=True,
+        indent=None,
+        separators=(",", ":"),
+    )
+
+
+def to_bytes(obj: object) -> bytes:
+    if obj is None or (isinstance(obj, str) and len(obj) < 1):
+        return b""
+    if djt.is_ndarray(obj):
+        return obj.tobytes()
+    return json_dumps(obj).encode()
+
+
+def simple_uuid(*args: object) -> UUID:
+    hashed = hashlib.md5()
+    for item in args:
+        hashed.update(to_bytes(item))
+    return UUID(hashed.hexdigest())
+
+
+def get_uuid(
+    obj: djt.UUIDLike,
+    from_key: djt.StrNone = None,
+    fallback_key: djt.StrNone = None,
+    allow_empty: bool = False,
+) -> UUID | None | NoReturn:
+    err_extend = ""
+    if isinstance(obj, (str, UUID)):
+        uuid = norm_uuid(obj)
+        if uuid:
+            return uuid
+    else:
+        if not from_key:
+            raise TypeError("'from_key' is required if 'obj' is not a string or UUID.")
+        err_extend = f" given key '{from_key}'"
+        uuid_like: object
+        if djt.is_strmap(obj, allow_empty=False):
+            uuid_like = obj.get(from_key, None)
+        elif djt.is_djtable(obj):
+            try:
+                uuid_like = obj.fetch1(from_key)
+            except Exception:
+                uuid_like = None
+        else:
+            uuid_like = None
+        uuid = norm_uuid(uuid_like)
+        if not uuid and fallback_key is not None:
+            uuid = get_uuid(obj, fallback_key, allow_empty=allow_empty)  # type: ignore
+    if uuid or allow_empty:
+        return uuid
+    obj_type = type(obj).__name__
+    raise ValueError(
+        f"Failed to return a UUID type object from a '{obj_type}'{err_extend}."
+    )
+
+
+# datajoint functions ------------------------------------------------------------------
+def dj_config_custom_entry(
+    key: str, *, fallback: object = None, envar: str = ""
+) -> object:
+    """Try to get a custom entry from the DataJoint configuration.
+
+    Priority:
+        1. DataJoint configuration's `custom` entry given `key`.
+        2. DataJoint configuration's top-level entry given `key`.
+        3. Environment variable specified by `envar`.
+        4. Fallback value given by `fallback`.
+
+    Args:
+        key (str): Key to look up in the DataJoint configuration.
+        fallback (object): Fallback value if `key` or `envar` is not found.
+        envar (str): Environment variable to use as a fallback.
+
+    Raises:
+        TypeError: If `custom` entry in the DataJoint configuration is not of the correct type.
+
+    Returns:
+        object: Value of the configuration entry.
+
+    Examples:
+            dj_config_custom_entry("database.prefix")
+    """
+    value = os.getenv(envar, fallback) if envar else fallback
+    custom: object = dj.config.get("custom", {})
+    if not djt.is_strmap(custom):
+        raise TypeError(f"Expected `custom` to be a dict, got {type(custom)}.")
+    return custom.get(key, dj.config.get(key, value))
+
+
+def get_prefix(fallback: str = "unknown_database", *, sep: str = "_") -> str:
+    """Get the database prefix from the `datajoint.config` property.
+
+    Args:
+        fallback (str, optional): Fallback value if prefix is not found. Defaults to
+            `"unknown_database"`.
+        sep (str, optional): Separator to append at the end of the prefix string.
+
+    Returns:
+        string: The database prefix string.
+
+    Examples:
+        Using the default values.
+
+            get_prefix()
+            > 'my_pkg_name_'
+    """
+    entry = dj_config_custom_entry(
+        "database.prefix", fallback=fallback, envar="DATABASE_PREFIX"
+    )
+    return f"{entry}{sep}" if entry else ""
+
+
+def append_to_prefix(name: str, **kwargs: str) -> str:
+    """Append a module name to the configured database prefix.
+
+    Args:
+        name (str): Name of module to append to database prefix.
+
+    Returns:
+        string: Extended database prefix.
+
+    Examples:
+        Using the default values.
+
+            append_to_prefix('core')
+            > 'my_pkg_name_core'
+    """
+    if not name:
+        raise ValueError("string to append cannot be empty.")
+    return get_prefix(**kwargs) + name
+
+
+def set_missing_configs(
+    *,
+    db_prefix: djt.StrNone = None,
+    db_host: str = "localhost",
+    db_user: str = "root",
+    db_pwd: str = "simple",
+    file: djt.StrPathNone = None,
+) -> None:
+    """Set common DataJoint configuration values _only_ if they are missing from the
+    existing config or configuration file.
+
+    Args:
+        db_prefix (str | None): Value to use for `"database.prefix"`.
+        db_host (str): Value to use for `"database.host"`.
+        db_user (str): Value to use for `"database.user"`.
+        db_pwd (str): Value to use for `"database.password"`.
+        file (Path | str | None): Path to initialize a datajoint `JSON` config
+            file before setting the rest of the arguments.
+    """
+
+    if file:
+        dj.config.load(file)
+
+    dj.config["database.user"] = dj.config.get("database.user") or db_user
+    dj.config["database.host"] = dj.config.get("database.host") or db_host
+    dj.config["database.password"] = dj.config.get("database.password") or db_pwd
+    dj.config["custom"] = {
+        **{"database.prefix": db_prefix or get_prefix(sep="")},
+        **dj.config.get("custom", {}),
+    }
+
+
+def insert_row(
+    cls: type[djt.T_UserTable],
+    attrs: djt.AnyMap,
+    **insert_opts: Unpack[djt.InsertOpts],
+) -> djt.T_UserTable:
+    cls().insert1(attrs, **insert_opts)  # type: ignore
+    pks: list[str] = cast(list[str], cls.primary_key)
+    key = subset(attrs, *pks)
+    restriction: djt.T_UserTable = cls & key
+    if not restriction:
+        raise QueryError(f"Insertion returned empty table given key:\n{key}")
+    return restriction

--- a/datajoint_utilities/generic/typed.py
+++ b/datajoint_utilities/generic/typed.py
@@ -168,7 +168,7 @@ def as_path_parts(file_or_parts: djt.StrPathParts) -> djt.StrTuple:
             f"not '{type(file_or_parts)}'"
         )
 
-    return (*filter(None, parts),)
+    return tuple(p for p in parts if p)
 
 
 def chain_path_parts(*args: djt.StrPathParts, sep: str = ".") -> str:

--- a/datajoint_utilities/generic/typed.py
+++ b/datajoint_utilities/generic/typed.py
@@ -228,7 +228,7 @@ def utc_timestamp(
 def is_empty_string(string: object, none_as_empty: bool = True) -> bool:
     if string is None:
         return none_as_empty
-    return isinstance(string, str) and string == ""
+    return isinstance(string, str) and not string 
 
 
 def arr_bool(obj: object) -> bool:

--- a/datajoint_utilities/generic/typed.py
+++ b/datajoint_utilities/generic/typed.py
@@ -355,7 +355,7 @@ class KWA:
         keys = KWA._keys_iterable(keys_from)
         extracted_kwargs = subset(kwargs, *keys)
         other_kwargs = {
-            k: v for k, v in kwargs.items() if k not in extracted_kwargs.keys()
+            k: v for k, v in kwargs.items() if k not in extracted_kwargs
         }
         return extracted_kwargs, other_kwargs
 

--- a/datajoint_utilities/py.typed
+++ b/datajoint_utilities/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/datajoint_utilities/typing/README.md
+++ b/datajoint_utilities/typing/README.md
@@ -1,0 +1,6 @@
+## `typing.py`
+
+> **Note**: This subdirectory is fully typed using python inline typing. It requires `python>=3.10` for some of the functionality.
+
+
+Type aliases, guards, and other generic typing information that can be shared across modules. Content can be used for inline type information for python objects.

--- a/datajoint_utilities/typing/__init__.py
+++ b/datajoint_utilities/typing/__init__.py
@@ -120,6 +120,7 @@ class SupportsBool(Protocol):
 T_Table = TypeVar("T_Table", bound=dj.expression.QueryExpression)
 T_UserTable = TypeVar("T_UserTable", bound=dj.user_tables.UserTable)
 BaseTable: TypeAlias = dj.expression.QueryExpression
+UserTable: TypeAlias = dj.user_tables.UserTable
 AnyTable: TypeAlias = (
     dj.expression.QueryExpression
     | dj.table.Table

--- a/datajoint_utilities/typing/__init__.py
+++ b/datajoint_utilities/typing/__init__.py
@@ -1,0 +1,179 @@
+from datajoint_utilities.generic.pkgutil import detect_min_python_version
+
+detect_min_python_version(3, 10)
+
+import datetime
+import inspect
+import types
+from pathlib import Path
+from typing import (
+    Any,
+    ItemsView,
+    Literal,
+    Mapping,
+    MutableMapping,
+    Protocol,
+    Sequence,
+    Sized,
+    TypeAlias,
+    TypedDict,
+    TypeGuard,
+    TypeVar,
+    cast,
+    runtime_checkable,
+)
+from uuid import UUID
+
+import datajoint as dj
+from numpy import bool_, complex_, float_, int_, ndarray, str_
+from numpy.typing import NDArray
+
+# Misc. typing -------------------------------------------------------------------------
+T = TypeVar("T")
+DictObj: TypeAlias = dict[str, object]
+DictAny: TypeAlias = dict[str, Any]
+AnyMap: TypeAlias = Mapping[str, object]
+AnyMutMap: TypeAlias = MutableMapping[str, object]
+StrNone: TypeAlias = str | None
+StrPath: TypeAlias = str | Path
+StrPathNone: TypeAlias = str | Path | None
+StrTuple: TypeAlias = tuple[str, ...]
+StrPathParts: TypeAlias = str | Path | StrTuple
+FrameType: TypeAlias = types.FrameType
+FrameInfo: TypeAlias = inspect.FrameInfo
+FrameInfoList: TypeAlias = list[FrameInfo]
+FrameStack: TypeAlias = FrameInfoList | FrameType
+FrameFile: TypeAlias = str | Path | FrameInfo
+FrameFileNone: TypeAlias = str | Path | FrameInfo | None
+AnyMapMapSeq: TypeAlias = AnyMap | Sequence[AnyMap]
+AnyMapStrSeq: TypeAlias = AnyMap | Sequence[str] | str
+TimeStampable: TypeAlias = datetime.datetime | datetime.date | datetime.timedelta
+UUIDStr: TypeAlias = str | UUID
+UUIDLike: TypeAlias = (
+    str | UUID | MutableMapping[str, str | UUID] | dj.expression.QueryExpression
+)
+ModuleType: TypeAlias = types.ModuleType
+
+
+def is_pathstr(obj: object) -> TypeGuard[StrPath]:
+    return isinstance(obj, (Path, str))
+
+
+def is_frame(obj: object) -> TypeGuard[FrameType]:
+    """Determines whether and object is a frame from inspect.currentframe."""
+    return isinstance(obj, types.FrameType)
+
+
+def is_frame_info(obj: object) -> TypeGuard[FrameInfo]:
+    """Determines whether and object is a frame from inspect.stack list."""
+    return isinstance(obj, inspect.FrameInfo)
+
+
+def is_frame_info_list(obj: object) -> TypeGuard[FrameInfoList]:
+    """Determines whether and object is a stack list inspect.stack."""
+    if not isinstance(obj, list):
+        return False
+    f: Any
+    for f in obj:
+        if not is_frame_info(f):
+            return False
+    return True
+
+
+def is_frame_stack(obj: object) -> TypeGuard[FrameStack]:
+    return is_frame(obj) or is_frame_info_list(obj)
+
+
+def is_strmap(obj: object, allow_empty: bool = True) -> TypeGuard[AnyMap]:
+    if not isinstance(obj, Mapping):
+        return False
+    if len(cast(Sized, obj)) == 0:
+        return allow_empty
+    return all(
+        isinstance(k, str) and isinstance(v, object)
+        for k, v in cast(ItemsView[Any, Any], obj.items())
+    )
+
+
+def is_uuid_str(obj: object) -> TypeGuard[UUIDStr]:
+    if isinstance(obj, UUID):
+        return True
+    elif isinstance(obj, str):
+        obj = obj.replace("urn:", "").replace("uuid:", "")
+        obj = obj.strip("{}").replace("-", "")
+        return len(obj) == 32
+    else:
+        return False
+
+
+def is_timestampable(obj: object) -> TypeGuard[TimeStampable]:
+    return isinstance(obj, (datetime.datetime, datetime.date, datetime.timedelta))
+
+
+@runtime_checkable
+class SupportsBool(Protocol):
+    def __bool__(self) -> bool:
+        ...
+
+
+# DataJoint typing ---------------------------------------------------------------------
+T_Table = TypeVar("T_Table", bound=dj.expression.QueryExpression)
+T_UserTable = TypeVar("T_UserTable", bound=dj.user_tables.UserTable)
+BaseTable: TypeAlias = dj.expression.QueryExpression
+AnyTable: TypeAlias = (
+    dj.expression.QueryExpression
+    | dj.table.Table
+    | dj.user_tables.UserTable
+    | dj.user_tables.TableMeta
+    | dj.user_tables.Lookup
+    | dj.user_tables.Manual
+    | dj.user_tables.Imported
+    | dj.user_tables.Computed
+    | dj.user_tables.Part
+)
+HeadingProp: TypeAlias = Literal["names", "primary_key", "secondary_attributes"]
+DBConnection: TypeAlias = dj.connection.Connection
+ContextLike: TypeAlias = AnyMap | FrameStack | types.ModuleType | str
+
+
+class InsertOpts(TypedDict, total=False):
+    replace: bool
+    skip_duplicates: bool
+    ignore_extra_fields: bool
+    allow_direct_insert: bool | None
+
+
+class InsertCallArgs(TypedDict):
+    row: DictObj
+    insert_opts: InsertOpts
+
+
+def is_djtable(obj: object) -> TypeGuard[dj.user_tables.UserTable]:
+    return isinstance(obj, BaseTable) or (
+        inspect.isclass(obj) and issubclass(obj, BaseTable)
+    )
+
+
+def is_parttable(obj: object) -> TypeGuard[dj.user_tables.Part]:
+    return inspect.isclass(obj) and issubclass(obj, dj.user_tables.Part)
+
+
+# Numpy typing -------------------------------------------------------------------------
+ArrayTypes: TypeAlias = bool_ | complex_ | float_ | int_ | str_
+VecTypes: TypeAlias = bool | complex | float | int | str
+NPArray: TypeAlias = NDArray[ArrayTypes]
+StrArray: TypeAlias = NDArray[str_]
+AnyArray: TypeAlias = NDArray[Any]
+Vector: TypeAlias = Sequence[VecTypes]
+ArrayOrVec: TypeAlias = (
+    NPArray
+    | Vector
+    | Sequence[Vector]
+    | Sequence[Sequence[Vector]]
+    | Sequence[Sequence[Sequence[Vector]]]
+    | Sequence[Sequence[Sequence[Sequence[Vector]]]]
+)
+
+
+def is_ndarray(obj: object) -> TypeGuard[AnyArray]:
+    return isinstance(obj, ndarray)

--- a/datajoint_utilities/typing/__init__.py
+++ b/datajoint_utilities/typing/__init__.py
@@ -89,10 +89,7 @@ def is_strmap(obj: object, allow_empty: bool = True) -> TypeGuard[AnyMap]:
         return False
     if len(cast(Sized, obj)) == 0:
         return allow_empty
-    return all(
-        isinstance(k, str) and isinstance(v, object)
-        for k, v in cast(ItemsView[Any, Any], obj.items())
-    )
+    return all(isinstance(k, str) for k, _ in cast(ItemsView[Any, Any], obj.items()))
 
 
 def is_uuid_str(obj: object) -> TypeGuard[UUIDStr]:

--- a/datajoint_utilities/typing/__init__.py
+++ b/datajoint_utilities/typing/__init__.py
@@ -5,23 +5,8 @@ detect_min_python_version(3, 10)
 import datetime
 import inspect
 import types
+import typing as typ
 from pathlib import Path
-from typing import (
-    Any,
-    ItemsView,
-    Literal,
-    Mapping,
-    MutableMapping,
-    Protocol,
-    Sequence,
-    Sized,
-    TypeAlias,
-    TypedDict,
-    TypeGuard,
-    TypeVar,
-    cast,
-    runtime_checkable,
-)
 from uuid import UUID
 
 import datajoint as dj
@@ -29,70 +14,73 @@ from numpy import bool_, complex_, float_, int_, ndarray, str_
 from numpy.typing import NDArray
 
 # Misc. typing -------------------------------------------------------------------------
-T = TypeVar("T")
-DictObj: TypeAlias = dict[str, object]
-DictAny: TypeAlias = dict[str, Any]
-AnyMap: TypeAlias = Mapping[str, object]
-AnyMutMap: TypeAlias = MutableMapping[str, object]
-StrNone: TypeAlias = str | None
-StrPath: TypeAlias = str | Path
-StrPathNone: TypeAlias = str | Path | None
-StrTuple: TypeAlias = tuple[str, ...]
-StrPathParts: TypeAlias = str | Path | StrTuple
-FrameType: TypeAlias = types.FrameType
-FrameInfo: TypeAlias = inspect.FrameInfo
-FrameInfoList: TypeAlias = list[FrameInfo]
-FrameStack: TypeAlias = FrameInfoList | FrameType
-FrameFile: TypeAlias = str | Path | FrameInfo
-FrameFileNone: TypeAlias = str | Path | FrameInfo | None
-AnyMapMapSeq: TypeAlias = AnyMap | Sequence[AnyMap]
-AnyMapStrSeq: TypeAlias = AnyMap | Sequence[str] | str
-TimeStampable: TypeAlias = datetime.datetime | datetime.date | datetime.timedelta
-UUIDStr: TypeAlias = str | UUID
-UUIDLike: TypeAlias = (
-    str | UUID | MutableMapping[str, str | UUID] | dj.expression.QueryExpression
+T = typ.TypeVar("T")
+DictObj: typ.TypeAlias = dict[str, object]
+DictAny: typ.TypeAlias = dict[str, typ.Any]
+AnyMap: typ.TypeAlias = typ.Mapping[str, object]
+AnyMutMap: typ.TypeAlias = typ.MutableMapping[str, object]
+StrNone: typ.TypeAlias = str | None
+StrPath: typ.TypeAlias = str | Path
+StrPathNone: typ.TypeAlias = str | Path | None
+StrTuple: typ.TypeAlias = tuple[str, ...]
+StrPathParts: typ.TypeAlias = str | Path | StrTuple
+FrameType: typ.TypeAlias = types.FrameType
+FrameInfo: typ.TypeAlias = inspect.FrameInfo
+FrameInfoList: typ.TypeAlias = list[FrameInfo]
+FrameStack: typ.TypeAlias = FrameInfoList | FrameType
+FrameFile: typ.TypeAlias = str | Path | FrameInfo
+FrameFileNone: typ.TypeAlias = str | Path | FrameInfo | None
+AnyMapMapSeq: typ.TypeAlias = AnyMap | typ.Sequence[AnyMap]
+AnyMapStrSeq: typ.TypeAlias = AnyMap | typ.Sequence[str] | str
+TimeStampable: typ.TypeAlias = datetime.datetime | datetime.date | datetime.timedelta
+UUIDStr: typ.TypeAlias = str | UUID
+UUIDLike: typ.TypeAlias = (
+    str | UUID | typ.MutableMapping[str, str | UUID] | dj.expression.QueryExpression
 )
-ModuleType: TypeAlias = types.ModuleType
+ModuleType: typ.TypeAlias = types.ModuleType
 
 
-def is_pathstr(obj: object) -> TypeGuard[StrPath]:
+def is_pathstr(obj: object) -> typ.TypeGuard[StrPath]:
     return isinstance(obj, (Path, str))
 
 
-def is_frame(obj: object) -> TypeGuard[FrameType]:
+def is_frame(obj: object) -> typ.TypeGuard[FrameType]:
     """Determines whether and object is a frame from inspect.currentframe."""
     return isinstance(obj, types.FrameType)
 
 
-def is_frame_info(obj: object) -> TypeGuard[FrameInfo]:
+def is_frame_info(obj: object) -> typ.TypeGuard[FrameInfo]:
     """Determines whether and object is a frame from inspect.stack list."""
     return isinstance(obj, inspect.FrameInfo)
 
 
-def is_frame_info_list(obj: object) -> TypeGuard[FrameInfoList]:
+def is_frame_info_list(obj: object) -> typ.TypeGuard[FrameInfoList]:
     """Determines whether and object is a stack list inspect.stack."""
     if not isinstance(obj, list):
         return False
-    f: Any
+    f: typ.Any
     for f in obj:
         if not is_frame_info(f):
             return False
     return True
 
 
-def is_frame_stack(obj: object) -> TypeGuard[FrameStack]:
+def is_frame_stack(obj: object) -> typ.TypeGuard[FrameStack]:
     return is_frame(obj) or is_frame_info_list(obj)
 
 
-def is_strmap(obj: object, allow_empty: bool = True) -> TypeGuard[AnyMap]:
-    if not isinstance(obj, Mapping):
+def is_strmap(obj: object, allow_empty: bool = True) -> typ.TypeGuard[AnyMap]:
+    if not isinstance(obj, typ.Mapping):
         return False
-    if len(cast(Sized, obj)) == 0:
+    if len(typ.cast(typ.Sized, obj)) == 0:
         return allow_empty
-    return all(isinstance(k, str) for k, _ in cast(ItemsView[Any, Any], obj.items()))
+    return all(
+        isinstance(k, str)
+        for k, _ in typ.cast(typ.ItemsView[typ.Any, typ.Any], obj.items())
+    )
 
 
-def is_uuid_str(obj: object) -> TypeGuard[UUIDStr]:
+def is_uuid_str(obj: object) -> typ.TypeGuard[UUIDStr]:
     if isinstance(obj, UUID):
         return True
     elif isinstance(obj, str):
@@ -103,22 +91,22 @@ def is_uuid_str(obj: object) -> TypeGuard[UUIDStr]:
         return False
 
 
-def is_timestampable(obj: object) -> TypeGuard[TimeStampable]:
+def is_timestampable(obj: object) -> typ.TypeGuard[TimeStampable]:
     return isinstance(obj, (datetime.datetime, datetime.date, datetime.timedelta))
 
 
-@runtime_checkable
-class SupportsBool(Protocol):
+@typ.runtime_checkable
+class SupportsBool(typ.Protocol):
     def __bool__(self) -> bool:
         ...
 
 
 # DataJoint typing ---------------------------------------------------------------------
-T_Table = TypeVar("T_Table", bound=dj.expression.QueryExpression)
-T_UserTable = TypeVar("T_UserTable", bound=dj.user_tables.UserTable)
-BaseTable: TypeAlias = dj.expression.QueryExpression
-UserTable: TypeAlias = dj.user_tables.UserTable
-AnyTable: TypeAlias = (
+T_Table = typ.TypeVar("T_Table", bound=dj.expression.QueryExpression)
+T_UserTable = typ.TypeVar("T_UserTable", bound=dj.user_tables.UserTable)
+BaseTable: typ.TypeAlias = dj.expression.QueryExpression
+UserTable: typ.TypeAlias = dj.user_tables.UserTable
+AnyTable: typ.TypeAlias = (
     dj.expression.QueryExpression
     | dj.table.Table
     | dj.user_tables.UserTable
@@ -129,49 +117,49 @@ AnyTable: TypeAlias = (
     | dj.user_tables.Computed
     | dj.user_tables.Part
 )
-HeadingProp: TypeAlias = Literal["names", "primary_key", "secondary_attributes"]
-DBConnection: TypeAlias = dj.connection.Connection
-ContextLike: TypeAlias = AnyMap | FrameStack | types.ModuleType | str
+HeadingProp: typ.TypeAlias = typ.Literal["names", "primary_key", "secondary_attributes"]
+DBConnection: typ.TypeAlias = dj.connection.Connection
+ContextLike: typ.TypeAlias = AnyMap | FrameStack | types.ModuleType | str
 
 
-class InsertOpts(TypedDict, total=False):
+class InsertOpts(typ.TypedDict, total=False):
     replace: bool
     skip_duplicates: bool
     ignore_extra_fields: bool
     allow_direct_insert: bool | None
 
 
-class InsertCallArgs(TypedDict):
+class InsertCallArgs(typ.TypedDict):
     row: DictObj
     insert_opts: InsertOpts
 
 
-def is_djtable(obj: object) -> TypeGuard[dj.user_tables.UserTable]:
+def is_djtable(obj: object) -> typ.TypeGuard[dj.user_tables.UserTable]:
     return isinstance(obj, BaseTable) or (
         inspect.isclass(obj) and issubclass(obj, BaseTable)
     )
 
 
-def is_parttable(obj: object) -> TypeGuard[dj.user_tables.Part]:
+def is_parttable(obj: object) -> typ.TypeGuard[dj.user_tables.Part]:
     return inspect.isclass(obj) and issubclass(obj, dj.user_tables.Part)
 
 
 # Numpy typing -------------------------------------------------------------------------
-ArrayTypes: TypeAlias = bool_ | complex_ | float_ | int_ | str_
-VecTypes: TypeAlias = bool | complex | float | int | str
-NPArray: TypeAlias = NDArray[ArrayTypes]
-StrArray: TypeAlias = NDArray[str_]
-AnyArray: TypeAlias = NDArray[Any]
-Vector: TypeAlias = Sequence[VecTypes]
-ArrayOrVec: TypeAlias = (
+ArrayTypes: typ.TypeAlias = bool_ | complex_ | float_ | int_ | str_
+VecTypes: typ.TypeAlias = bool | complex | float | int | str
+NPArray: typ.TypeAlias = NDArray[ArrayTypes]
+StrArray: typ.TypeAlias = NDArray[str_]
+AnyArray: typ.TypeAlias = NDArray[typ.Any]
+Vector: typ.TypeAlias = typ.Sequence[VecTypes]
+ArrayOrVec: typ.TypeAlias = (
     NPArray
     | Vector
-    | Sequence[Vector]
-    | Sequence[Sequence[Vector]]
-    | Sequence[Sequence[Sequence[Vector]]]
-    | Sequence[Sequence[Sequence[Sequence[Vector]]]]
+    | typ.Sequence[Vector]
+    | typ.Sequence[typ.Sequence[Vector]]
+    | typ.Sequence[typ.Sequence[typ.Sequence[Vector]]]
+    | typ.Sequence[typ.Sequence[typ.Sequence[typ.Sequence[Vector]]]]
 )
 
 
-def is_ndarray(obj: object) -> TypeGuard[AnyArray]:
+def is_ndarray(obj: object) -> typ.TypeGuard[AnyArray]:
     return isinstance(obj, ndarray)

--- a/datajoint_utilities/version.py
+++ b/datajoint_utilities/version.py
@@ -1,3 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.9.*
+  - python>=3.9
   - pip
   - setuptools>=62.0.0
   - cryptography
@@ -33,6 +33,7 @@ dependencies:
   - ipykernel
   - pip:
       - datajoint
-      - ruamel.yaml
       - python-dotenv
+      - slack-sdk
+      - ruamel.yaml
       - "-e ."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 datajoint>=0.13.5
 termcolor
 slack-sdk
+python-dotenv

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/datajoint-company/datajoint-utilities",
     packages=setuptools.find_packages(exclude=["test*", "docs"]),
+    package_data={"datajoint_utilities": ["py.typed"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
@@ -30,4 +31,5 @@ setuptools.setup(
         "console_scripts": ("tmplcfg=datajoint_utilities.cmdline.tmplcfg:cli",),
     },
     install_requires=requirements,
+    zip_safe=False,
 )


### PR DESCRIPTION
- Type aliases, guards, and other generic typing information that can be shared across modules
- Location to store generic utilities that can be used across modules and packages
- `LazySchema` modifies the DataJoint `Schema` class to always delay activation of a `Schema` instance