### PR TITLE
Integrate notification (PopulateHandler) into DataJointWorker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
 
+## [0.7.0] - 2025-10-31
+
+### Added
+- PopulateHandler now supports per-table notification configuration with dynamic table addition
+- DataJointWorker integration with notification system:
+  - Optional notifiers parameter to enable notifications
+  - Per-table notification control via `notify_on` parameter in `add_step()` and `__call__()`
+  - Automatic DEBUG log level management for PopulateHandler visibility
+
 ## [0.6.2] - 2025-06-04
 
 - Fix - bugfix data copy with DataJoint's latest `topo_sort()`

--- a/datajoint_utilities/dj_notification/loghandler.py
+++ b/datajoint_utilities/dj_notification/loghandler.py
@@ -71,9 +71,7 @@ class PopulateHandler(StreamHandler):
             "Error making": "ERROR",
         }[status]
 
-        if full_table_name not in self.tables_to_notify:
-            return
-        if not self.tables_to_notify[full_table_name][status.lower()]:
+        if self.tables_to_notify.get(full_table_name, {}).get(status.lower(), False):
             return
 
         try:

--- a/datajoint_utilities/dj_notification/loghandler.py
+++ b/datajoint_utilities/dj_notification/loghandler.py
@@ -1,22 +1,27 @@
 from logging import StreamHandler
 import re
+import ast
 import datajoint as dj
-import json
+from typing import List, Any, Optional
 
 
 class PopulateHandler(StreamHandler):
     """
-    Custom Log Handler to parse and handle DataJoint logs related to populating tables.
+    Log handler that parses DataJoint populate logs and sends notifications.
+    
+    Monitors log entries for "Making", "Success making", "Error making" patterns,
+    extracts table names and keys, then notifies configured notifiers per table.
+    Supports per-table notification settings and dynamic table addition.
     """
 
     _patterns = ("Making", "Error making", "Success making")
 
     def __init__(
-        self, notifiers, full_table_names, on_start=True, on_success=True, on_error=True
-    ):
+        self, notifiers: List[Any], full_table_names: Optional[List[str]] = None, on_start: bool = True, on_success: bool = True, on_error: bool = True
+    ) -> None:
         """
         :param notifiers: list of instantiated "Notifier"
-        :param full_table_names: list of full table names to get notified about
+        :param full_table_names: list of full table names to get notified about (optional)
         :param on_start: (bool) notify on populate start (default=True)
         :param on_success: (bool) notify on populate finishes successfully (default=True)
         :param on_error: (bool) notify on populate errors out (default=True)
@@ -25,24 +30,36 @@ class PopulateHandler(StreamHandler):
         StreamHandler.__init__(self)
         assert all(hasattr(notifier, "notify") for notifier in notifiers)
         self.notifiers = notifiers
-        self.full_table_names = full_table_names
-        self._status_to_notify = {
+        self.tables_to_notify: dict = {}
+        if full_table_names:
+            for full_table_name in full_table_names:
+                self.watch_table(full_table_name, on_start, on_success, on_error)
+
+    def watch_table(self, full_table_name: str, on_start: bool = True, on_success: bool = True, on_error: bool = True) -> None:
+        """
+        Add a table to watch for populate notifications.
+        
+        :param full_table_name: Full table name (schema.table)
+        :param on_start: Notify when populate starts (default=True)
+        :param on_success: Notify when populate succeeds (default=True)
+        :param on_error: Notify when populate fails (default=True)
+        """
+        self.tables_to_notify[full_table_name] = {
             "start": on_start,
             "success": on_success,
             "error": on_error,
         }
 
-    def emit(self, record):
+    def emit(self, record: Any) -> None:
         msg = self.format(record)
         if not any(p in msg for p in self._patterns):
             return
         match = re.search(
             r"(Making|Success making|Error making) (.*) -> (\S+)( - .*)?", msg
         )
+        if not match:
+            return
         status, key_str, full_table_name, error_message = match.groups()
-
-        key = json.loads(key_str.replace("'", '"'))
-        error_message = error_message.replace(" - ", "") if error_message else ""
 
         status = {
             "Making": "START",
@@ -50,24 +67,34 @@ class PopulateHandler(StreamHandler):
             "Error making": "ERROR",
         }[status]
 
-        if (
-            not self._status_to_notify[status.lower()]
-            or full_table_name not in self.full_table_names
-        ):
+        if full_table_name not in self.tables_to_notify:
+            return
+        if not self.tables_to_notify[full_table_name][status.lower()]:
             return
 
-        schema_name, table_name = full_table_name.split(".")
-        schema_name = schema_name.strip("`")
-        table_name = dj.utils.to_camel_case(table_name.strip("`"))
+        try:
+            key = ast.literal_eval(key_str)
+            error_message = error_message.replace(" - ", "") if error_message else ""
+
+            schema_name, table_name = full_table_name.split(".")
+            schema_name = schema_name.strip("`")
+            table_name = dj.utils.to_camel_case(table_name.strip("`"))
+        except (ValueError, SyntaxError, AttributeError, KeyError, IndexError):
+            # Skip malformed log entries silently
+            return
 
         for notifier in self.notifiers:
-            notifier.notify(
-                title=f"DataJoint populate - {schema_name}.{table_name} - {status}",
-                message=msg,
-                schema_name=schema_name,
-                table_name=table_name,
-                key=key,
-                status=status,
-                error_message=error_message,
-                **key,
-            )
+            try:
+                notifier.notify(
+                    title=f"DataJoint populate - {schema_name}.{table_name} - {status}",
+                    message=msg,
+                    schema_name=schema_name,
+                    table_name=table_name,
+                    key=key,
+                    status=status,
+                    error_message=error_message,
+                    **key,
+                )
+            except Exception as e:
+                # Log notifier errors but continue with other notifiers
+                print(f"PopulateHandler: Notifier failed: {e}")

--- a/datajoint_utilities/dj_notification/loghandler.py
+++ b/datajoint_utilities/dj_notification/loghandler.py
@@ -36,8 +36,6 @@ class PopulateHandler(StreamHandler):
         if full_table_names is not None:
             for full_table_name in full_table_names:
                 self.watch_table(full_table_name, on_start, on_success, on_error)
-        else:
-            self.watch_table(on_start, on_success, on_error)
 
     def watch_table(self, full_table_name: str, on_start: bool = True, on_success: bool = True, on_error: bool = True) -> None:
         """

--- a/datajoint_utilities/dj_notification/loghandler.py
+++ b/datajoint_utilities/dj_notification/loghandler.py
@@ -28,12 +28,16 @@ class PopulateHandler(StreamHandler):
         """
 
         StreamHandler.__init__(self)
-        assert all(hasattr(notifier, "notify") for notifier in notifiers)
+        for notifier in notifiers:
+            if not hasattr(notifier, "notify"):
+                raise ValueError(f"Not a valid `Notifier` - missing `notify` method")
         self.notifiers = notifiers
         self.tables_to_notify: dict = {}
-        if full_table_names:
+        if full_table_names is not None:
             for full_table_name in full_table_names:
                 self.watch_table(full_table_name, on_start, on_success, on_error)
+        else:
+            self.watch_table(on_start, on_success, on_error)
 
     def watch_table(self, full_table_name: str, on_start: bool = True, on_success: bool = True, on_error: bool = True) -> None:
         """

--- a/datajoint_utilities/dj_notification/loghandler.py
+++ b/datajoint_utilities/dj_notification/loghandler.py
@@ -69,7 +69,7 @@ class PopulateHandler(StreamHandler):
             "Error making": "ERROR",
         }[status]
 
-        if self.tables_to_notify.get(full_table_name, {}).get(status.lower(), False):
+        if not self.tables_to_notify.get(full_table_name, {}).get(status.lower(), False):
             return
 
         try:

--- a/datajoint_utilities/dj_worker/worker.py
+++ b/datajoint_utilities/dj_worker/worker.py
@@ -277,7 +277,7 @@ class DataJointWorker:
             # Functions don't support notifications, ignore notification parameters
             self._processes_to_run.insert(index, ("function", callable, kwargs))
         else:
-            raise NotImplemented(
+            raise NotImplementedError(
                 f"Unable to handle processing step of type {type(callable)}"
             )
         self._is_registered = False

--- a/datajoint_utilities/version.py
+++ b/datajoint_utilities/version.py
@@ -1,3 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datajoint-utilities"
-version = "0.6.2"
+version = "0.7.0"
 description = "A general purpose repository containing all generic tools/utilities surrounding the DataJoint ecosystem"
 requires-python = ">=3.9, <3.12"
 license = { file = "LICENSE" }


### PR DESCRIPTION
This pull request introduces notification support for DataJoint worker processes, allowing users to receive notifications for table population events such as start, success, and error. The changes add a new `PopulateHandler` log handler, integrate it into the worker class, and provide flexible per-table notification configuration.

- PopulateHandler now supports per-table notification configuration with dynamic table addition
- DataJointWorker integration with notification system:
  - Optional notifiers parameter to enable notifications
  - Per-table notification control via `notify_on` parameter in `add_step()` and `__call__()`
  - Automatic DEBUG log level management for PopulateHandler visibility

Example usage

```
from datajoint_utilities.dj_notification.notifier.slack_notifier import SlackWebhookNotifier
from datajoint_utilities.dj_worker import DataJointWorker

webhook_url = os.getenv("SLACK_WEBHOOK_URL")
notifiers = [SlackWebhookNotifier(webhook_url)]

standard_worker = DataJointWorker(
    "standard_worker",
    worker_schema_name,
    notifiers=notifiers,
)

standard_worker(miniscope.RecordingInfo, max_calls=5, notify_on=["start", "error"])
standard_worker(miniscope.Processing, max_calls=3, notify_on=["start", "success", "error"])
standard_worker(miniscope.MotionCorrection, max_calls=5, notify_on=["error"])
standard_worker(miniscope.Segmentation, max_calls=5, notify_on=["success", "error"])
```