### PR TITLE
fix: validate table existence before querying in RegisteredWorker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
 
+## [0.7.1] - 2025-12-14
+
+- Fix - validate table existence in RegisteredWorker (remove/optimize the `len()` call)
+
 ## [0.7.0] - 2025-10-31
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datajoint-utilities"
-version = "0.7.0"
+version = "0.7.1"
 description = "A general purpose repository containing all generic tools/utilities surrounding the DataJoint ecosystem"
 requires-python = ">=3.9, <3.12"
 license = { file = "LICENSE" }


### PR DESCRIPTION
The `len(target)` call in `get_incomplete_key_source_sql` function is for the purpose of validating that the target_table does exist. But this is a potentially very expensive call (for large tables) - and this validation step should belong in one step above, in the `get_key_source_count` function. 

Replace #55 
