### PR TITLE
fix: resolve class mutation bug causing connection cross-contamination

### DIFF
--- a/datajoint_utilities/dj_worker/__init__.py
+++ b/datajoint_utilities/dj_worker/__init__.py
@@ -1,7 +1,17 @@
 import argparse
 import logging
 
-from .worker import RegisteredWorker, WorkerLog, ErrorLog, DataJointWorker, logger
+from .worker import (
+    RegisteredWorker,
+    WorkerLog,
+    ErrorLog,
+    DataJointWorker,
+    logger,
+    # Module-level functions (preferred over deprecated class methods)
+    get_workers_progress,
+    get_key_source_count,
+    get_incomplete_key_source_sql,
+)
 
 
 # arg-parser for usage as CLI

--- a/datajoint_utilities/dj_worker/worker.py
+++ b/datajoint_utilities/dj_worker/worker.py
@@ -45,6 +45,10 @@ from .worker_schema import (
     ErrorLog,
     get_process_name,
     is_djtable,
+    # Module-level functions (preferred over class methods)
+    get_workers_progress,
+    get_key_source_count,
+    get_incomplete_key_source_sql,
 )
 
 logger = dj.logger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datajoint-utilities"
-version = "0.7.1"
+version = "0.8.0"
 description = "A general purpose repository containing all generic tools/utilities surrounding the DataJoint ecosystem"
 requires-python = ">=3.9, <3.12"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Fixes #57 - Schema decoration was mutating shared table classes (`RegisteredWorker`), causing `_connection` to be overwritten when processing multiple projects. This led to queries executing against wrong databases in concurrent/sequential multi-project scenarios.

## Changes

- **New module-level functions** with explicit `connection` parameter (safe API):
  - `get_workers_progress(registered_worker_table, connection, ...)`
  - `get_key_source_count(connection, ...)`
  - `get_incomplete_key_source_sql(connection, ...)`

- **Deprecated class methods** with `DeprecationWarning` for backward compatibility

- **Fixed `get_workflow_operation_overview()`** to use VirtualModule's spawned table instead of decorating shared class

## Migration

```python
# Before (deprecated, has bug)
RegisteredWorker.get_workers_progress()

# After (safe)
from datajoint_utilities.dj_worker import get_workers_progress
workerlog_vm = dj.create_virtual_module("vm", schema_name, connection=conn)
get_workers_progress(workerlog_vm.RegisteredWorker, conn)
```

## Version

0.7.1 → 0.8.0 (minor, backward compatible with deprecation warnings)